### PR TITLE
Change rubytree gem dependency link 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ source 'https://rubygems.org'
 
 gem 'cucumber', '~> 2.2'
 gem 'rest-client'
-gem 'rubytree'
+gem 'rubytree', git: 'https://github.com/razboev/RubyTree'
 gem 'rspec'
 gem 'rake'
 gem 'parallel_tests'

--- a/reportportal.gemspec
+++ b/reportportal.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.license                = 'LGPL-3.0'
 
   s.add_dependency('rest-client', '~> 2.0')
+  s.add_dependency('rubytree', '>=0.9.3')
 end

--- a/reportportal.gemspec
+++ b/reportportal.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |s|
   s.license                = 'LGPL-3.0'
 
   s.add_dependency('rest-client', '~> 2.0')
-  s.add_dependency('rubytree', '>=0.9.3')
 end


### PR DESCRIPTION
Due to this issue https://github.com/reportportal/agent-ruby/issues/10
As possible solution we can use another link 
https://github.com/evolve75/RubyTree/pull/62 for more information