### PR TITLE
launch_id for new launches can be changed via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Supported settings:
  - project - project name
  - tags - array of tags for the launch
  - formatter_modes - array of modes that modify formatter behavior, see [formatter modes](#formatter_modes)
- - launch_id - id of previously created launch (to be used if formatter_modes contains attach_to_launch)
- - file_with_launch_id - path to file with id of launch (to be used if formatter_modes contains attach_to_launch)
+ - launch_id - if `formatter_modes` contains `attach_to_launch` then it specifies id of previously created launch. Otherwise, it's a custom launch id to be used instead of default value (cucumber ARGV)  
+ - file_with_launch_id - path to file with id of launch (to be used if `formatter_modes` contains `attach_to_launch`)
  - disable_ssl_verification - set to true to disable SSL verification on connect to ReportPortal (potential security hole!). Set `disable_ssl_verification` to `true` if you see the following error:
 ```
 Request to https://rp.epam.com/reportportal-ws/api/v1/pass-team/launch//finish produced an exception: RestClient::SSLCertificateNotVerified: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed

--- a/lib/report_portal/cucumber/report.rb
+++ b/lib/report_portal/cucumber/report.rb
@@ -53,8 +53,9 @@ module ReportPortal
             end
           $stdout.puts "Attaching to launch #{ReportPortal.launch_id}"
         else
-          cmd_args = ARGV.map { |arg| arg.gsub(/rp_uuid=.+/, "rp_uuid=[FILTERED]") }.join(' ')
-          ReportPortal.start_launch(cmd_args, time_to_send(desired_time))
+          new_launch_id = ReportPortal::Settings.instance.launch_id
+          new_launch_id ||= ARGV.map { |arg| arg.gsub(/rp_uuid=.+/, "rp_uuid=[FILTERED]") }.join(' ')
+          ReportPortal.start_launch(new_launch_id, time_to_send(desired_time))
         end
       end
 


### PR DESCRIPTION
Custom launch ID may be assigned for new launches instead of cucumber command line options.