### PR TITLE
Add a mode to skip reporting item hierarchy

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -121,7 +121,7 @@ Metrics/BlockLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 165
+  Max: 169
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following modes are supported:
 | --- | --- |
 | attach_to_launch | Do not create a new launch but add executing features/scenarios to an existing launch. Use launch_id or file_with_launch_id settings to configure that. If they are not present client will check rp_launch_id.tmp in `Dir.tmpdir`)
 | use_same_thread_for_reporting | Send reporting commands in the same main thread used for running tests. This mode is useful for debugging this Report Portal client. It changes default behavior to send commands in the separate thread. Default behavior is there not to slow test execution. |
+| skip_reporting_hierarchy | Do not create items for folders and feature files |
 
 ## Logging
 Experimental support for three common logging frameworks was added:

--- a/config/report_portal.yaml.example
+++ b/config/report_portal.yaml.example
@@ -3,6 +3,6 @@ endpoint: https://localhost:8443/api/v1
 launch: example_launch_name
 project: default_project
 tags: [tag1, tag2, tag3]
-#formatter_modes: [group_by_folder]
+#formatter_modes: [skip_reporting_hierarchy]
 #is_debug: true
 #disable_ssl_verification: true

--- a/lib/report_portal/cucumber/parallel_report.rb
+++ b/lib/report_portal/cucumber/parallel_report.rb
@@ -1,3 +1,5 @@
+require 'parallel_tests'
+
 require_relative 'report'
 
 module ReportPortal
@@ -11,6 +13,7 @@ module ReportPortal
 
       def initialize
         @root_node = Tree::TreeNode.new('')
+        @parent_item_node = @root_node
         @last_used_time ||= 0
 
         if ParallelTests.first_process?
@@ -30,8 +33,8 @@ module ReportPortal
         end
       end
 
-      def done(desired_time = ReportPortal.now)
-        end_feature(desired_time) if @feature_node
+      def test_run_finished(_event, desired_time = ReportPortal.now)
+        end_feature(desired_time) unless @parent_item_node.is_root?
 
         if ParallelTests.first_process?
           ParallelTests.wait_for_other_processes_to_finish

--- a/tests/report_portal.yaml
+++ b/tests/report_portal.yaml
@@ -4,7 +4,7 @@ project: default_project
 launch: Test report portal
 tags: [external_site, desktop]
 
-#formatter_modes: [group_by_folder]
+#formatter_modes: [skip_reporting_hierarchy]
 #is_debug: true
 #disable_ssl_verification: true
 #thread_cool_off_timeout: 15


### PR DESCRIPTION
Currently, it's not easy to implement parallel distributed running of tests to Report Portal.
There are some options:
* create a launch per Cucumber process and then merge them
* create items for all folders before running tests

But they are not perfect. Ideally, [a special command is needed in Report Portal BE side to support parallel reporting](https://github.com/reportportal/reportportal/issues/611).

To work around this issue, this PR adds a mode to skip reporting of folder and feature items.