### PR TITLE
Add a mode to use the same main thread for reporting instead of the separate one

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ WebMock.disable_net_connect!(:net_http_connect_on_start => true, :allow_localhos
 
 The following modes are supported:
 
-* attach_to_launch (do not create a new launch but add executing features/scenarios to an existing launch. Use launch_id or file_with_launch_id settings to configure that. If they are not present client will check rp_launch_id.tmp in `Dir.tmpdir`)
-* group_by_folder (represent folders with features as nested suites in Report Portal) # TODO: not supported by new Cucumber formatter currently
+| Name | Purpose |
+| --- | --- |
+| attach_to_launch | Do not create a new launch but add executing features/scenarios to an existing launch. Use launch_id or file_with_launch_id settings to configure that. If they are not present client will check rp_launch_id.tmp in `Dir.tmpdir`)
+| use_same_thread_for_reporting | Send reporting commands in the same main thread used for running tests. This mode is useful for debugging this Report Portal client. It changes default behavior to send commands in the separate thread. Default behavior is there not to slow test execution. |
 
 ## Logging
 Experimental support for three common logging frameworks was added:

--- a/lib/report_portal/cucumber/formatter.rb
+++ b/lib/report_portal/cucumber/formatter.rb
@@ -9,40 +9,65 @@ module ReportPortal
       def initialize(config)
         ENV['REPORT_PORTAL_USED'] = 'true'
 
-        @queue = Queue.new
-        @thread = Thread.new do
-          @report = ReportPortal::Cucumber::Report.new
-          loop do
-            method_arr = @queue.pop
-            @report.public_send(*method_arr)
-          end
-        end
-        @thread.abort_on_exception = true
+        setup_message_processing
 
         @io = config.out_stream
 
-        [:test_case_started, :test_case_finished, :test_step_started, :test_step_finished].each do |event_name|
+        [:test_case_started, :test_case_finished, :test_step_started, :test_step_finished, :test_run_finished].each do |event_name|
           config.on_event event_name do |event|
-            @queue.push([event_name, event, ReportPortal.now])
+            process_message(event_name, event)
           end
         end
-        config.on_event :test_run_finished, &method(:on_test_run_finished)
+        config.on_event(:test_run_finished) { finish_message_processing }
       end
 
       def puts(message)
-        @queue.push([:puts, message, ReportPortal.now])
+        process_message(:puts, message)
         @io.puts(message)
         @io.flush
       end
 
       def embed(*args)
-        @queue.push([:embed, *args, ReportPortal.now])
+        process_message(:embed, *args)
       end
 
-      def on_test_run_finished(_event)
-        @queue.push([:done, ReportPortal.now])
+      private
+
+      def report
+        @report ||= ReportPortal::Cucumber::Report.new
+      end
+
+      def setup_message_processing
+        return if use_same_thread_for_reporting?
+
+        @queue = Queue.new
+        @thread = Thread.new do
+          loop do
+            method_arr = @queue.pop
+            report.public_send(*method_arr)
+          end
+        end
+        @thread.abort_on_exception = true
+      end
+
+      def finish_message_processing
+        return if use_same_thread_for_reporting?
+
         sleep 0.03 while !@queue.empty? || @queue.num_waiting == 0 # TODO: how to interrupt launch if the user aborted execution
         @thread.kill
+      end
+
+      def process_message(report_method_name, *method_args)
+        args = [report_method_name, *method_args, ReportPortal.now]
+        if use_same_thread_for_reporting?
+          report.public_send(*args)
+        else
+          @queue.push(args)
+        end
+      end
+
+      def use_same_thread_for_reporting?
+        ReportPortal::Settings.instance.formatter_modes.include?('use_same_thread_for_reporting')
       end
     end
   end

--- a/lib/report_portal/cucumber/parallel_formatter.rb
+++ b/lib/report_portal/cucumber/parallel_formatter.rb
@@ -1,34 +1,13 @@
 require_relative 'formatter'
 require_relative 'parallel_report'
-require 'parallel_tests/gherkin/io'
 
 module ReportPortal
   module Cucumber
     class ParallelFormatter < Formatter
-      #include ::ParallelTests::Gherkin::Io
+      private
 
-      # @api private
-      def initialize(config)
-        ENV['REPORT_PORTAL_USED'] = 'true'
-
-        @queue = Queue.new
-        @thread = Thread.new do
-          @report = ReportPortal::Cucumber::ParallelReport.new
-          loop do
-            method_arr = @queue.pop
-            @report.public_send(*method_arr)
-          end
-        end
-        @thread.abort_on_exception = true
-
-        @io = config.out_stream
-
-        [:test_case_started, :test_case_finished, :test_step_started, :test_step_finished].each do |event_name|
-          config.on_event event_name do |event|
-            @queue.push([event_name, event, ReportPortal.now])
-          end
-        end
-        config.on_event :test_run_finished, &method(:on_test_run_finished)
+      def report
+        @report ||= ReportPortal::Cucumber::ParallelReport.new
       end
     end
   end


### PR DESCRIPTION
Debugging of multi-threaded code is less easy than when there's only one thread.
This PR adds a mode to do reporting in the same main thread.