### PR TITLE
Correct the gem's dependency management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,4 @@
 
 source 'https://rubygems.org'
 
-gem 'cucumber', '~> 3'
-gem 'rest-client'
-gem 'rubytree', git: 'https://github.com/razboev/RubyTree'
-gem 'rspec'
-gem 'rake'
-gem 'parallel_tests', '2.15.0'
-gem 'sys-proctable', '1.1.5'
-
-gem 'logging'
-gem 'log4r'
+gemspec

--- a/lib/report_portal/version.rb
+++ b/lib/report_portal/version.rb
@@ -17,5 +17,5 @@
 # along with Report Portal.  If not, see <http://www.gnu.org/licenses/>.
 
 module ReportPortal
-  VERSION = '0.7'
+  VERSION = '0.7.1'
 end

--- a/reportportal.gemspec
+++ b/reportportal.gemspec
@@ -32,6 +32,16 @@ Gem::Specification.new do |s|
   s.required_ruby_version  = '>= 1.9.3'
   s.license                = 'LGPL-3.0'
 
-  s.add_dependency('rest-client', '~> 2.0')
-  s.add_dependency('rubytree', '>=0.9.3')
+  s.add_runtime_dependency('rest-client', '~> 2.0')
+  
+  s.add_runtime_dependency('cucumber', '~> 3.0')
+  s.add_runtime_dependency('rubytree', '~> 1.0')
+  s.add_runtime_dependency('rspec', '~> 3.8')
+  s.add_runtime_dependency('rake', '~> 12.3')
+  s.add_runtime_dependency('parallel_tests', '~> 2.15')
+  s.add_runtime_dependency('sys-proctable', '1.1.5')
+
+  s.add_runtime_dependency('logging', '~> 2.2')
+  s.add_runtime_dependency('log4r', '~> 1.1')
+
 end


### PR DESCRIPTION
The origin branch fixed the problem with using parallel_cucumber with RP but the gem management is broken (dependencies for a gem should be declared in the .gemspec and not in the Gemfile or Bundler won't fetch the dependencies correctly when the gem is used).

I've also taken the liberty to specify version requirements for the dependencies, per best practice, and used the pessimistic operator to lock to major versions.

If this PR is accepted, could the built gem be pushed to RubyGems?