### PR TITLE
Use persistent client for HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 * reportportal/reportportal#293 - Re-licence client side to Apache 2.0
 * Remove multipart monkeypatch of RestClient. Replace RestClient with HTTP gem as it supports multipart fine
+* Make `/api/v1` not required as part of endpoint in report_portal.yml
+* Add a mode to use persistent HTTP connection

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following modes are supported:
 | attach_to_launch | Do not create a new launch but add executing features/scenarios to an existing launch. Use launch_id or file_with_launch_id settings to configure that. If they are not present client will check rp_launch_id.tmp in `Dir.tmpdir`)
 | use_same_thread_for_reporting | Send reporting commands in the same main thread used for running tests. This mode is useful for debugging this Report Portal client. It changes default behavior to send commands in the separate thread. Default behavior is there not to slow test execution. |
 | skip_reporting_hierarchy | Do not create items for folders and feature files |
+| use_persistent_connection | Use persistent connection to connect to the server |
 
 ## Logging
 Experimental support for three common logging frameworks was added:

--- a/config/report_portal.yaml.example
+++ b/config/report_portal.yaml.example
@@ -1,5 +1,5 @@
 uuid: 12345678-1234-1234-1234-123456789012
-endpoint: https://localhost:8080/api/v1
+endpoint: https://localhost:8080
 launch: example_launch_name
 project: default_personal
 tags: [tag1, tag2, tag3]

--- a/lib/report_portal/http_client.rb
+++ b/lib/report_portal/http_client.rb
@@ -1,0 +1,64 @@
+require 'http'
+
+module ReportPortal
+  # @api private
+  class HttpClient
+    def initialize
+      create_client
+    end
+
+    def send_request(verb, path, options = {})
+      path.prepend("/api/v1/#{Settings.instance.project}/")
+      path.prepend(origin) unless use_persistent?
+      3.times do
+        begin
+          response = @http.request(verb, path, options)
+        rescue StandardError => e
+          puts "Request #{request_info(verb, path)} produced an exception:"
+          puts e
+          recreate_client
+        else
+          return response.parse(:json) if response.status.success?
+
+          message = "Request #{request_info(verb, path)} returned code #{response.code}."
+          message << " Response:\n#{response}" unless response.to_s.empty?
+          puts message
+        end
+      end
+    end
+
+    private
+
+    def create_client
+      @http = HTTP.auth("Bearer #{Settings.instance.uuid}")
+      @http = @http.persistent(origin) if use_persistent?
+      add_insecure_ssl_options if Settings.instance.disable_ssl_verification
+    end
+
+    def add_insecure_ssl_options
+      ssl_context = OpenSSL::SSL::SSLContext.new
+      ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      @http.default_options = { ssl_context: ssl_context }
+    end
+
+    # Response should be consumed before sending next request via the same persistent connection.
+    # If an exception occurred, there may be no response so a connection has to be recreated.
+    def recreate_client
+      @http.close
+      create_client
+    end
+
+    def request_info(verb, path)
+      uri = URI.join(origin, path)
+      "#{verb.upcase} `#{uri}`"
+    end
+
+    def origin
+      Addressable::URI.parse(Settings.instance.endpoint).origin
+    end
+
+    def use_persistent?
+      ReportPortal::Settings.instance.formatter_modes.include?('use_persistent_connection')
+    end
+  end
+end

--- a/lib/report_portal/settings.rb
+++ b/lib/report_portal/settings.rb
@@ -44,10 +44,6 @@ module ReportPortal
       setting('formatter_modes') || []
     end
 
-    def project_url
-      "#{endpoint}/#{project}"
-    end
-
     private
 
     def setting(key)

--- a/lib/reportportal.rb
+++ b/lib/reportportal.rb
@@ -1,10 +1,12 @@
 require 'cgi'
-require 'json'
 require 'http'
+require 'json'
 require 'pathname'
 require 'tempfile'
+require 'uri'
 
 require_relative 'report_portal/settings'
+require_relative 'report_portal/http_client'
 
 module ReportPortal
   TestItem = Struct.new(:name, :type, :id, :start_time, :description, :closed, :tags)
@@ -141,27 +143,11 @@ module ReportPortal
     private
 
     def send_request(verb, path, options = {})
-      if Settings.instance.disable_ssl_verification
-        options[:ssl_context] = OpenSSL::SSL::SSLContext.new
-        options[:ssl_context].verify_mode = OpenSSL::SSL::VERIFY_NONE
-      end
-      uri = "#{Settings.instance.project_url}/#{path}"
-      retries = 0
-      while retries < 3
-        begin
-          response = HTTP.auth("Bearer #{Settings.instance.uuid}").request(verb, uri, options)
-          return response.parse(:json) if response.status.success?
+      http_client.send_request(verb, path, options)
+    end
 
-          message = "Request to `#{uri}` returned code #{response.code}."
-          message << " Response:\n#{response}" unless response.to_s.empty?
-          puts message
-          retries += 1
-        rescue StandardError => e
-          puts "Request to `#{uri}` produced an exception:"
-          puts e
-          retries += 1
-        end
-      end
+    def http_client
+      @http_client ||= HttpClient.new
     end
   end
 end


### PR DESCRIPTION
Persistent connections (keep-alive) significantly improve request-response cycle speed if the connection between hosts is not very fast.

On the other hand, if the connection is very good, persistent connections [may reduce speed a bit](https://stackoverflow.com/q/8636841/841064)

Below are details of the benchmark I made to check the performance improvement of persistent connections for our case.

I introduced a config option so it would be easy to check it in other scenarios too.

**Benchmark 1 - remote endpoint**

YAML file:
```
uuid: my-uuid
endpoint: https://web.demo.reportportal.io
launch: example_launch_name
project: abotalov_personal
formatter_modes: [skip_reporting_hierarchy, use_same_thread_for_reporting]
disable_ssl_verification: false
```

Command (ran from my laptop, currently located in Spain):
```
for run in {1..5}; do bundle exec cucumber tests/features/ -r tests/features/ -f ReportPortal::Cucumber::Formatter; done
```

Execution time using `persistent-benchmark` branch:
```
86.00392306
85.71174958
84.6365683
100.3799417
107.1182389
```
Average is 92 seconds.

Execution time using `non-persistent-benchmark` branch (the only change from `persistent-benchmark` branch is usage of non-persistent connections):
```
305.279757
294.4467745
305.1522905
302.4168719
307.5853562
```
Average is 302 seconds. Time on `master` branch is similar, by the way.

So persistent connections improve speed by ~3 times under conditions of this benchmark.

**Benchmark 2 - localhost endpoint**

I ran the same command 20 times against Report Portal server on my laptop.

Average using persistent connection - 12.8 seconds.
Average using non-persistent connection - 11.5 seconds.

So persistent connections were 10% slower for some reason.