### PR TITLE
Refactor sending file

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,7 +33,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 121
+  Max: 127
 
 # Offense count: 4
 Metrics/PerceivedComplexity:

--- a/lib/report_portal/cucumber/report.rb
+++ b/lib/report_portal/cucumber/report.rb
@@ -130,8 +130,8 @@ module ReportPortal
         ReportPortal.send_log(:info, message, time_to_send(desired_time))
       end
 
-      def embed(src, mime_type, label, desired_time = ReportPortal.now)
-        ReportPortal.send_file(:info, src, label, time_to_send(desired_time), mime_type)
+      def embed(path_or_src, mime_type, label, desired_time = ReportPortal.now)
+        ReportPortal.send_file(:info, path_or_src, label, time_to_send(desired_time), mime_type)
       end
 
       private

--- a/reportportal.gemspec
+++ b/reportportal.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.license                = 'Apache-2.0'
 
   s.add_dependency('http', '~> 4.0')
+  s.add_dependency('mime-types')
   s.add_dependency('rubytree', '>=0.9.3')
 
   s.add_development_dependency('rubocop', '0.71')

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -1,15 +1,21 @@
+require 'base64'
 require 'cucumber'
 require 'pathname'
 
-$odd_even = 0
-$odd_even_started = false
+file_path = Pathname(__dir__).parent.parent + 'assets' + 'crane.png'
 
-After do |scenario|
-  $odd_even += 1 if $odd_even_started
-  if scenario.failed?
-    image = Pathname(__FILE__).dirname.parent.parent + 'assets' + 'crane.png'
-    embed image, 'image/png', 'Failure screenshot'
-  end
+After('@file_via_path') do
+  embed file_path, 'image/png', 'Image'
+end
+
+After('@file_via_src') do
+  src = File.read(file_path, mode: 'rb')
+  embed src, 'image/png', 'Image'
+end
+
+After('@file_via_base64_src') do
+  base64_src = Base64.encode64(File.read(file_path, mode: 'rb'))
+  embed base64_src, 'image/png;base64', 'Image'
 end
 
 Before('@pass_before') do

--- a/tests/features/without_background.feature
+++ b/tests/features/without_background.feature
@@ -204,3 +204,15 @@ Feature: Scenarios without background
     | don't like    |
     | hate          |
     | despise       |
+
+  @file_via_path
+  Scenario: With a file passed using a path
+    Given Passing step #1
+
+  @file_via_src
+  Scenario: With a file passed using source
+    Given Passing step #1
+
+  @file_via_base64_src
+  Scenario: With a file passed using base64 source
+    Given Passing step #1


### PR DESCRIPTION
It contains the following changes:
* NULLs are removed from the string before passing it to `File.file?`. Reason is this method raises an error if NULLs are present.
* Tempfile is closed after the file is sent to Report Portal