### PR TITLE
Allow starting a test item with custom parameters

### DIFF
--- a/lib/report_portal/event_bus.rb
+++ b/lib/report_portal/event_bus.rb
@@ -1,0 +1,30 @@
+require_relative 'events/prepare_start_item_request'
+
+module ReportPortal
+  # @api private
+  class EventBus
+    attr_reader :event_types
+
+    def initialize
+      @event_types = {
+        prepare_start_item_request: Events::PrepareStartItemRequest
+      }
+      @handlers = {}
+    end
+
+    def on(event_name, &proc)
+      handlers_for(event_name) << proc
+    end
+
+    def broadcast(event_name, **attributes)
+      event = event_types.fetch(event_name).new(**attributes)
+      handlers_for(event_name).each { |handler| handler.call(event) }
+    end
+
+    private
+
+    def handlers_for(event_name)
+      @handlers[event_name] ||= []
+    end
+  end
+end

--- a/lib/report_portal/events/prepare_start_item_request.rb
+++ b/lib/report_portal/events/prepare_start_item_request.rb
@@ -1,0 +1,13 @@
+module ReportPortal
+  module Events
+    # An event executed before sending a StartTestItem request.
+    class PrepareStartItemRequest
+      # A hash that contains keys like item's `start_time`, `name`, `description`.
+      attr_reader :request_data
+
+      def initialize(request_data:)
+        @request_data = request_data
+      end
+    end
+  end
+end

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -47,3 +47,14 @@ AfterStep do
     raise 'I failed!'
   end
 end
+
+AfterConfiguration do |config|
+  config.on_event :test_run_started do
+    ReportPortal.on_event :prepare_start_item_request do |rp_event|
+      rp_event.request_data[:parameters] = [{ key: 'param_name', value: 'param_value' }]
+    end
+    ReportPortal.on_event :prepare_start_item_request do |rp_event|
+      rp_event.request_data[:parameters] << { key: 'param_name2', value: 'param_value2' }
+    end
+  end
+end


### PR DESCRIPTION
Sometimes, there is a need to customize what is reported.
E.g. add a parameter or change description for a test item, change a description for a launch, etc.

When such customizations are too specific for a particular use case, they can be supported only via some hook system or monkeypatches. Hook system is better as it's easier to support for an end user.

This PR adds a hook system and a PrepareStartItemRequest hook. This hook can be used to customize description, parameters, tags, etc. sent in StartItem request.