### PR TITLE
Return status when getting test items

### DIFF
--- a/lib/report_portal/models/test_item.rb
+++ b/lib/report_portal/models/test_item.rb
@@ -1,7 +1,7 @@
 module ReportPortal
   # Represents a test item
   class TestItem
-    attr_reader :launch_id, :unique_id, :name, :description, :type, :parameters, :tags, :start_time
+    attr_reader :launch_id, :unique_id, :name, :description, :type, :parameters, :tags, :status, :start_time
     attr_accessor :id, :closed
 
     def initialize(options = {})
@@ -13,6 +13,7 @@ module ReportPortal
       @type = options[:type]
       @parameters = options[:parameters]
       @tags = options[:tags]
+      @status = options[:status]
       @start_time = options[:start_time]
       @id = options[:id]
       @closed = options[:closed]


### PR DESCRIPTION
`get_items` returns a list of elements - https://github.com/reportportal/agent-ruby/blob/ce1c34140d0177bc929bc51129f85ce6752df3c0/lib/reportportal.rb#L111
But only some fields are filled in. This change makes `status` filled in as well.