### PR TITLE
#85 - Send attributes (key value pair) to reportportal

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Supported settings:
  - launch - launch name
  - description - custom launch description
  - project - project name
- - tags - array of tags for the launch
+ - attributes - launch attributes. key value object
  - formatter_modes - array of modes that modify formatter behavior, see [formatter modes](#formatter_modes)
  - launch_id - id of previously created launch (to be used if formatter_modes contains attach_to_launch)
  - file_with_launch_id - path to file with id of launch (to be used if formatter_modes contains attach_to_launch)

--- a/config/report_portal.yaml.example
+++ b/config/report_portal.yaml.example
@@ -2,7 +2,11 @@ uuid: 12345678-1234-1234-1234-123456789012
 endpoint: https://localhost:8080
 launch: example_launch_name
 project: default_personal
-tags: [tag1, tag2, tag3]
+attributes:
+  - key: build
+    value: '0.1'
+  - value: test
+#tags: [tag1, tag2, tag3] - DEPRECATED. Use attributes instead
 #formatter_modes: [skip_reporting_hierarchy]
 #is_debug: true
 #disable_ssl_verification: true

--- a/lib/report_portal/settings.rb
+++ b/lib/report_portal/settings.rb
@@ -18,8 +18,9 @@ module ReportPortal
         'endpoint' => true,
         'project' => true,
         'launch' => true,
-        'description' => false,
         'tags' => false,
+        'description' => false,
+        'attributes' => false,
         'is_debug' => false,
         'disable_ssl_verification' => false,
         # for parallel execution only

--- a/lib/reportportal.rb
+++ b/lib/reportportal.rb
@@ -37,7 +37,9 @@ module ReportPortal
     end
 
     def start_launch(description, start_time = now)
-      data = { name: Settings.instance.launch, start_time: start_time, tags: Settings.instance.tags, description: description, mode: Settings.instance.launch_mode }
+      required_data = {name: Settings.instance.launch, start_time: start_time, description:
+          description, mode: Settings.instance.launch_mode }
+      data = prepare_options(required_data, params=Settings.instance)
       @launch_id = send_request(:post, 'launch', json: data)['id']
     end
 
@@ -199,5 +201,15 @@ module ReportPortal
     def event_bus
       @event_bus ||= EventBus.new
     end
+
+    def prepare_options(data, config = {})
+      if config.attributes
+        data[:attributes] = config.attributes
+      else
+        data[:tags] = config.tags if config.tags
+      end
+      data
+    end
+
   end
 end


### PR DESCRIPTION
Add the option to send key value launch attributes in order to be able to facilitate filtering data 