### PR TITLE
Add new option logLaunchLink to print Launch URL in console

### DIFF
--- a/config/report_portal.yaml.example
+++ b/config/report_portal.yaml.example
@@ -2,6 +2,7 @@ uuid: 12345678-1234-1234-1234-123456789012
 endpoint: https://localhost:8080
 launch: example_launch_name
 project: default_personal
+logLaunchLink: true
 attributes:
   - key: build
     value: '0.1'

--- a/lib/report_portal/settings.rb
+++ b/lib/report_portal/settings.rb
@@ -26,7 +26,8 @@ module ReportPortal
         # for parallel execution only
         'use_standard_logger' => false,
         'launch_id' => false,
-        'file_with_launch_id' => false
+        'file_with_launch_id' => false,
+        'logLaunchLink' => false
       }
 
       keys.each do |key, is_required|

--- a/lib/reportportal.rb
+++ b/lib/reportportal.rb
@@ -45,7 +45,11 @@ module ReportPortal
 
     def finish_launch(end_time = now)
       data = { end_time: end_time }
-      send_request(:put, "launch/#{@launch_id}/finish", json: data)
+      @finished_launch = send_request(:put, "launch/#{@launch_id}/finish", json: data)
+      @launch_link = @finished_launch['link']
+      if Settings.instance.logLaunchLink
+      	print "Launch ID ReportPortal: #{@launch_link}"
+      end
     end
 
     def start_item(item_node)


### PR DESCRIPTION
Add a new option in the reportportal.rb and settings.rb to print the URL of the Launch of the tests.

The idea is to provide a way to easily verify the result of the tests after the execution.

An example of the object:

> uuid: 12345678-1234-1234-1234-123456789012
> endpoint: https://localhost:8080
> launch: example_launch_name
> project: default_personal
> logLaunchLink: true
> attributes:
>   - key: build
>     value: '0.1'
>   - value: test
> #tags: [tag1, tag2, tag3] - DEPRECATED. Use attributes instead
> #formatter_modes: [skip_reporting_hierarchy]
> #is_debug: true
> #disable_ssl_verification: true


And then in the finish of the execution the Launch Link will be printed:

Launch ID ReportPortal: http://host/ui/#project_name/launches/all/id